### PR TITLE
Initial Multiplayer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.import
+.vscode
+export_presets.cfg

--- a/OQ_Toolkit/OQ_UI2D/scripts/OQ_UI2DLabel.gd
+++ b/OQ_Toolkit/OQ_UI2D/scripts/OQ_UI2DLabel.gd
@@ -17,7 +17,7 @@ export var transparent := false;
 
 onready var ui_label : Label = $Viewport/ColorRect/CenterContainer/Label
 onready var ui_container : CenterContainer = $Viewport/ColorRect/CenterContainer
-onready var ui_color_rect : CenterContainer = $Viewport/ColorRect
+onready var ui_color_rect : ColorRect = $Viewport/ColorRect
 onready var ui_viewport : Viewport = $Viewport
 onready var mesh_instance : MeshInstance = $MeshInstance
 var ui_mesh : PlaneMesh = null;

--- a/dynamic_objects/PlayerDummy.tscn
+++ b/dynamic_objects/PlayerDummy.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://dynamic_objects/scripts/PlayerDummy.gd" type="Script" id=1]
+
+[node name="Spatial" type="Spatial"]
+script = ExtResource( 1 )

--- a/dynamic_objects/Toolbelt.tscn
+++ b/dynamic_objects/Toolbelt.tscn
@@ -8,8 +8,8 @@ script = ExtResource( 1 )
 
 [node name="Slots" type="Spatial" parent="."]
 
-[node name="Toolbelt_Slot_1" parent="Slots" instance=ExtResource( 2 )]
+[node name="right" parent="Slots" instance=ExtResource( 2 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.1, 0, 0.3 )
 
-[node name="Toolbelt_Slot_2" parent="Slots" instance=ExtResource( 2 )]
+[node name="left" parent="Slots" instance=ExtResource( 2 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.1, 0, -0.3 )

--- a/dynamic_objects/scripts/Container_Crate.gd
+++ b/dynamic_objects/scripts/Container_Crate.gd
@@ -37,63 +37,59 @@ func apply_save_dictionary(r : Dictionary):
 func update_label_text():
 	label.set_label_text(str(_item_counter) + " X " + _stored_def_name)
 
-
-func can_grab():
-	if (_item_counter > 0): return true;
-	return false;
-
-func get_grab_object(controller):
-	if (_item_counter > 0):
-		var def = vdb.get_def_from_name(_stored_def_name);
-		if (def == null):
-			vr.log_error("Invalid def in Container_Crate");
-			return null;
-			
-		_item_counter -= 1;
-		#print("returning item from crate")
-		var obj = vdb.create_object_from_def(def);
-		add_child(obj);
-		update_label_text();
-		vdb._play_sfx(vdb.sfx_craft_success, controller.global_transform.origin);
-		return obj;
-	
-	return null;
-	
-func check_and_put_in_crate(obj):
-	if (obj == null):
-		vr.log_warning("check_and_put_in_crate() with null object");
-		return false;
-	
+func can_put(obj):
 	if (not obj is Spatial):
-		vr.log_warning("check_and_put_in_crate() object " + str(obj) + "is not Spatial");
+		vr.log_warning("can_put() object " + str(obj) + "is not Spatial");
 		return false;
 		
-	if (!obj.visible): return false; # safety check to avoid readding invisible objects
-	
-	
-	var def_name = obj.get_def_name();
-	
-	if (_item_counter == 0):
-		_stored_def_name = def_name;
+	if (!obj.visible):
+		return false; # safety check to avoid readding invisible objects
+
+	if _item_counter == 0:
+		return true;
+
+	return _stored_def_name == obj.get_def_name();
+
+func put_item(obj):
+	if _item_counter == 0:
+		_stored_def_name = obj.get_def_name();
 		var geom = obj.get_geometry_node()
 		geom.get_parent().remove_child(geom);
 		add_child(geom);
 		geom.transform.origin = Vector3(0.5, 0.5, 0.5);
-	
-	if (_stored_def_name != def_name):
-		vdb._play_sfx(vdb.sfx_metal_footstep, obj.global_transform.origin);
-		return false;
-	else:
-		_item_counter += 1;
-		vdb._play_sfx(vdb.sfx_craft_success, obj.global_transform.origin);
-		update_label_text();
-		# removeing is currently done by the caller
-#		obj.visible = false;
-#		obj.queue_free();
-		return true;
-	
-		
+
+	obj.visible = false;
+	obj.queue_free();
+
+	_item_counter += 1;
+	vdb._play_sfx(vdb.sfx_craft_success, obj.global_transform.origin);
+	update_label_text();
+
+func can_grab(controller):
+	if (_item_counter > 0): return true;
 	return false;
+
+func request_grab(hand_name):
+	vdb.voxel_world_player.request_from_crate(hand_name, global_transform.origin);
+
+func get_grab_object():
+	if (_item_counter == 0):
+		return null;
+
+	var def = vdb.get_def_from_name(_stored_def_name);
+	if (def == null):
+		vr.log_error("Invalid def in Container_Crate");
+		return null;
+		
+	_item_counter -= 1;
+	update_label_text();
+	
+	var obj = vdb.create_object_from_def(def);
+	vdb.voxel_world_player.parent_world.add_child(obj);
+
+	vdb._play_sfx(vdb.sfx_craft_success, global_transform.origin + Vector3.ONE / 2);
+
+	return obj;
 	
 func _show_label():
 	update_label_text();

--- a/dynamic_objects/scripts/Item_CraftingGuide.gd
+++ b/dynamic_objects/scripts/Item_CraftingGuide.gd
@@ -34,6 +34,7 @@ var _num_pages = 1;
 
 var _grabbing_controller = null;
 
+# todo controller param
 func get_grab_object(controller):
 	_grabbing_controller = controller;
 	return self;

--- a/dynamic_objects/scripts/Object_Item.gd
+++ b/dynamic_objects/scripts/Object_Item.gd
@@ -1,5 +1,6 @@
 extends Spatial
 
+var uuid = vdb.gen_uuid();
 var _item_def = null;
 
 func _has_predefined_geometry():
@@ -29,10 +30,11 @@ func apply_save_dictionary(r : Dictionary):
 func get_voxel_def():
 	return null;
 
-func can_grab():
+func can_grab(controller):
 	return true;
 
-
+func request_grab(hand_name):
+	vdb.voxel_world_player.request_grab(hand_name, uuid);
 
 func get_grab_object(controller):
 	return self;

--- a/dynamic_objects/scripts/Object_VoxelBlock.gd
+++ b/dynamic_objects/scripts/Object_VoxelBlock.gd
@@ -1,5 +1,6 @@
 extends Spatial
 
+var uuid = vdb.gen_uuid();
 var _voxel_def = null;
 
 func get_def():
@@ -24,8 +25,11 @@ func apply_save_dictionary(r : Dictionary):
 func get_voxel_def():
 	return _voxel_def;
 
-func can_grab():
+func can_grab(controller):
 	return true;
+
+func request_grab(hand_name):
+	vdb.voxel_world_player.request_grab(hand_name, uuid);
 
 func get_grab_object(controller):
 	return self;

--- a/dynamic_objects/scripts/PlayerDummy.gd
+++ b/dynamic_objects/scripts/PlayerDummy.gd
@@ -1,0 +1,237 @@
+extends Spatial
+
+var uuid;
+
+var INVENTORY_SIZE = 8;
+var _inventory = [];
+var active_inventory_slot = 0;
+
+var _toolbelt = {
+	left = null,
+	right = null
+};
+
+var _hands = {
+	left = {
+		held_item = null,
+		transform = Transform.IDENTITY,
+		last_transform = null
+	},
+	right = {
+		held_item = null,
+		transform = Transform.IDENTITY,
+		last_transform = null
+	}
+};
+
+const INTERPOLATION_DURATION = 1 / 20;
+var _t = 0;
+
+func _ready():
+	for _i in range(0, INVENTORY_SIZE):
+		_inventory.append([null, 0]);
+
+func _process(delta):
+	_t += delta;
+
+	_update_hand(_hands.left);
+	_update_hand(_hands.right);
+
+func _update_hand(hand):
+	if !hand.held_item:
+		return;
+
+	var viewed_transform = hand.transform;
+	
+	if hand.last_transform && _t < INTERPOLATION_DURATION:
+		viewed_transform = hand.last_transform.interpolate_with(hand.transform, _t / INTERPOLATION_DURATION);
+
+	hand.held_item.global_transform = viewed_transform;
+
+###
+
+func update_positions(left_hand_transform, right_hand_transform):
+	_t = 0;
+	_hands.left.last_transform = _hands.left.transform;
+	_hands.right.last_transform = _hands.right.transform;
+	
+	_hands.left.transform = left_hand_transform;
+	_hands.right.transform = right_hand_transform;
+
+func load_player_data(data):
+	uuid = data.uuid;
+
+	apply_inventory_save_dict(data.inventory);
+
+	if(data.toolbelt_left):
+		var def = vdb.get_def_from_name(data.toolbelt_left.name);
+		var item = vdb.create_object_from_def(def);
+		item.uuid = data.toolbelt_left.uuid;
+
+		_toolbelt.left = item;
+
+	if(data.toolbelt_right):
+		var def = vdb.get_def_from_name(data.toolbelt_right.name);
+		var item = vdb.create_object_from_def(def);
+		item.uuid = data.toolbelt_right.uuid;
+
+		_toolbelt.right = item;
+
+	if(data.hand_left):
+		var def = vdb.get_def_from_name(data.hand_left.name);
+		var item = vdb.create_object_from_def(def);
+		item.uuid = data.hand_left.uuid;
+
+		_hands.left.held_item = item;
+
+	if(data.hand_right):
+		var def = vdb.get_def_from_name(data.hand_right.name);
+		var item = vdb.create_object_from_def(def);
+		item.uuid = data.hand_right.uuid;
+		
+		_hands.right.held_right = item;
+
+func apply_inventory_save_dict(data):
+	active_inventory_slot = data.active_inventory_slot;
+
+	for i in range(0, INVENTORY_SIZE):
+		var def_name = data.def_names[i];
+		var def = null;
+		
+		if def_name:
+			def = vdb.get_def_from_name(def_name);
+		
+		_inventory[i][0] = def;
+		_inventory[i][1] = data.item_count[i];
+
+### core Player interface
+
+func gen_player_data():
+	var data = {
+		uuid = uuid,
+		inventory = {
+			def_names = [],
+			item_count = [],
+			active_inventory_slot = active_inventory_slot
+		},
+		toolbelt_left = null,
+		toolbelt_right = null,
+		hand_left = null,
+		hand_right = null
+	};
+
+	for i in range(0, INVENTORY_SIZE):
+		var slot = _inventory[i];
+		var item_name = null;
+
+		if(slot[0]):
+			item_name = slot[0].name;
+
+		data.inventory.def_names.append(item_name);
+		data.inventory.item_count.append(slot[1]);
+
+	if(_toolbelt.left):
+		data.toolbelt_left = {
+			uuid = _toolbelt.left.uuid,
+			name = _toolbelt.left.get_def().name
+		};
+
+	if(_toolbelt.right):
+		data.toolbelt_right = {
+			uuid = _toolbelt.right.uuid,
+			name = _toolbelt.right.get_def().name
+		};
+
+	if(_hands.left.held_item):
+		data.hand_left = {
+			uuid = _hands.left.held_item.uuid,
+			name = _hands.left.held_item.get_def().name
+		};
+
+	if(_hands.right.held_item):
+		data.hand_right = {
+			uuid = _hands.right.held_item.uuid,
+			name = _hands.right.held_item.get_def().name
+		};
+
+	return data;
+
+func grab_with(hand_name, item):
+	_hands[hand_name].held_item = item;
+
+func release_with(hand_name):
+	var hand = _hands[hand_name];
+	var item = hand.held_item;
+	hand.held_item = null;
+	
+	return item;
+
+func get_held_object(hand_name):
+	return _hands[hand_name].held_item;
+
+func delete_held_item(hand_name):
+	var item = _hands[hand_name].held_item;
+	
+	if !item:
+		return;
+
+	item.queue_free();
+
+	_hands[hand_name].held_item = null;
+
+func give_item(item_def, slot):
+	_inventory[slot][0] = item_def;
+	_inventory[slot][1] += 1;
+
+func get_available_slot(voxel_or_item_def):
+	var empty_space = -1;
+
+	for pos_it in range(0, INVENTORY_SIZE):
+		# start at the displayed slot and wrap around
+		var slot = (pos_it + active_inventory_slot) % INVENTORY_SIZE;
+		var item = _inventory[slot][0];
+		var item_count = _inventory[slot][1];
+
+		# get first available slot
+		if !item && empty_space == -1:
+			empty_space = slot;
+
+		# return a stackable slot
+		if item && item.name == voxel_or_item_def.name && item_count < item.stackability:
+			return slot;
+	
+	return empty_space;
+
+func take_item_from_slot(slot):
+	# construct a new object and spawn it into the world
+	if (_inventory[slot][1] <= 0): return null; # nothing to grab in the inventory
+
+	var def = _inventory[slot][0];
+	_inventory[slot][1] -= 1;
+	
+	if (_inventory[slot][1] == 0):
+		_inventory[slot][0] = null;
+
+	var voxel_object = vdb.create_object_from_def(def);
+	vdb.voxel_world_player.parent_world.add_child(voxel_object);
+
+	return voxel_object;
+
+func set_active_slot(slot):
+	active_inventory_slot = slot;
+
+func move_held_item_to_tool_slot(hand_name, slot_name):
+	var item = _hands[hand_name].held_item;
+	
+	item.get_parent().remove_child(item);
+
+	_toolbelt[slot_name] = item;
+	_hands[hand_name].held_item = null;
+
+func move_tool_to_hand(slot_name, hand_name):
+	var item = _toolbelt[slot_name];
+
+	vdb.voxel_world_player.parent_world.add_child(item);
+
+	_hands[hand_name].held_item = item;
+	_toolbelt[slot_name] = null;

--- a/dynamic_objects/scripts/Toolbelt.gd
+++ b/dynamic_objects/scripts/Toolbelt.gd
@@ -1,5 +1,6 @@
 extends Spatial
 
+var slots = {}
 
 func get_save_dictionary() -> Dictionary:
 	var ret = {
@@ -42,17 +43,10 @@ func apply_save_dictionary(r : Dictionary):
 			if (slot == null):
 				vr.log_error("Non-existing item slot for tool in toolbelt");
 			else:
-				slot.check_and_put_in_toolbelt_slot(obj);
+				slot.put_item(obj);
 			
 		else:
 			vr.log_error("Could not load object from " + str(item));
-
-
-func check_and_put_in_toolbelt(held_obj):
-	for slot in $Slots.get_children():
-		if slot.check_and_put_in_toolbelt_slot(held_obj):
-			return true;
-	return false;
 
 
 func _physics_process(_dt):
@@ -60,4 +54,5 @@ func _physics_process(_dt):
 	global_transform.origin.y -= vr.get_current_player_height() * 0.5;
 
 func _ready():
-	pass # Replace with function body.
+	for slot in $Slots.get_children():
+		slots[slot.name] = slot;

--- a/levels/VoxelWorldPlayer.tscn
+++ b/levels/VoxelWorldPlayer.tscn
@@ -134,5 +134,10 @@ editor_live_update = false
 transparent = false
 
 [node name="CreativeModeMainUI" parent="CreativeModeStuff/OQ_UI2D_CreativeModeMainUI" instance=ExtResource( 1 )]
+
+[node name="Timer" type="Timer" parent="."]
+wait_time = 0.05
+autostart = true
 [connection signal="grab_released_held_object" from="OQ_ARVROrigin/OQ_LeftController/ObjectGrabber" to="." method="_on_ObjectGrabber_grab_released_held_object"]
 [connection signal="grab_released_held_object" from="OQ_ARVROrigin/OQ_RightController/ObjectGrabber" to="." method="_on_ObjectGrabber_grab_released_held_object"]
+[connection signal="timeout" from="Timer" to="." method="_send_positions"]

--- a/logic/core.gd
+++ b/logic/core.gd
@@ -1,0 +1,532 @@
+extends Node
+
+var server = null;
+var users_by_socket_id = {};
+
+func start_server():
+	var Server = load("res://networking/SocketServer.gd");
+	server = Server.new();
+
+	server.on("connect", self, "_user_connected");
+	server.on("identify", self, "_load_user");
+	server.on("position_player", self, "_position_player");
+	server.on("disconnect", self, "_user_disconnected");
+	server.on("attempt_craft", self, "_user_attempt_craft")
+	server.on("attempt_build", self, "_user_attempt_build");
+	server.on("attempt_break", self, "_user_attempt_break");
+	server.on("creative_build", self, "_creative_build");
+	server.on("creative_destroy", self, "_creative_destroy");
+	server.on("grab_item", self, "_grab_item");
+	server.on("grab_from_crate", self, "_grab_from_crate");
+	server.on("grab_from_inventory", self, "_grab_from_inventory");
+	server.on("move_to_inventory", self, "_move_to_inventory");
+	server.on("set_active_slot", self, "_set_active_slot");
+	server.on("move_to_tool_slot", self, "_move_to_tool_slot");
+	server.on("move_tool_to_hand", self, "_move_tool_to_hand");
+	server.on("release_grab", self, "_release_grab");
+
+	server.start()
+
+func stop_server():
+	users_by_socket_id = {};
+	server.stop_server();
+	server = null;
+
+### event listeners
+
+func _user_connected(id: int):
+	# send world data to the player
+
+	# this is actually just world nodes
+	# inventory data is separated
+	var persisted_nodes = [ vdb.voxel_world_player ];
+
+	var world_data = vdb._get_save_dictionary(persisted_nodes);
+	var player_data = [ vdb.voxel_world_player.gen_player_data() ];
+	
+	for dummy_player in vdb.voxel_world_player.user_dummy_by_uuid.values():
+		dummy_player.gen_player_data();
+
+	server.send_reliable(id, "world_data", [ world_data, player_data ]);
+
+func _load_user(id: int, uuid: String, preferences: Dictionary):
+	if vdb.voxel_world_player.user_dummy_by_uuid.has(uuid):
+		server.kick(id);
+		return;
+
+	users_by_socket_id[id] = {
+		socket_id = id,
+		uuid = uuid,
+		preferences = preferences
+	};
+
+	vdb.voxel_world_player.add_player(uuid);
+
+	server.broadcast_reliable("add_player", [ uuid ]);
+
+func _position_player(id: int, left_hand_transform, right_hand_transform):
+	var user = users_by_socket_id[id];
+	
+	update_player_positions(user.uuid, left_hand_transform, right_hand_transform);
+
+func _user_disconnected(id: int):
+	var user = users_by_socket_id[id];
+	users_by_socket_id.erase(id);
+
+	vdb.voxel_world_player.remove_player(user.uuid);
+
+	server.broadcast_reliable("remove_player", [ user.uuid ]);
+
+	# drop inventory?
+
+func _user_attempt_craft(id: int, voxel_pos, hand_name, is_physical):
+	var user = users_by_socket_id[id];
+	player_craft_with(user.uuid, voxel_pos, hand_name, is_physical);
+
+func _user_attempt_build(id: int, voxel_pos, pos, hand_name, is_physical):
+	var user = users_by_socket_id[id];
+	attempt_build(user.uuid, voxel_pos, pos, hand_name, is_physical);
+
+func _user_attempt_break(id: int, voxel_pos, hit_pos, hand_name, is_physical):
+	var user = users_by_socket_id[id];
+	attempt_break(user.uuid, user.preferences, voxel_pos, hit_pos, hand_name, is_physical);
+
+func _creative_build(id: int, voxel_pos, voxel_id):
+	var user = users_by_socket_id[id];
+	add_voxel(user.uuid, voxel_pos, voxel_id, false);
+
+func _creative_destroy(id: int, voxel_pos):
+	var user = users_by_socket_id[id];
+	remove_voxel(user.uuid, voxel_pos, false);
+
+func _grab_item(id: int, hand_name, item_uuid):
+	var user = users_by_socket_id[id];
+	
+	player_grab_item(user.uuid, hand_name, item_uuid);
+
+func _grab_from_crate(id: int, hand_name, crate_position):
+	var user = users_by_socket_id[id];
+
+	player_take_from_crate(user.uuid, hand_name, crate_position);
+
+func _grab_from_inventory(id: int, hand_name, slot):
+	var user = users_by_socket_id[id];
+
+	player_grab_from_inventory(user.uuid, hand_name, slot);
+
+func _move_to_inventory(id: int, hand_name, slot):
+	var user = users_by_socket_id[id];
+
+	move_to_inventory(user.uuid, hand_name, slot);
+
+func _set_active_slot(id: int, slot):
+	var user = users_by_socket_id[id];
+
+	set_player_active_slot(user.uuid, slot);
+
+func _move_to_tool_slot(id: int, hand_name, slot):
+	var user = users_by_socket_id[id];
+
+	move_to_tool_slot(user.uuid, hand_name, slot);
+
+func _move_tool_to_hand(id: int, slot, hand_name):
+	var user = users_by_socket_id[id];
+
+	move_tool_to_hand(user.uuid, slot, hand_name);
+
+func _release_grab(id: int, hand_name, final_transform):
+	var user = users_by_socket_id[id];
+
+	player_release_item(user.uuid, hand_name, final_transform);
+
+### messages
+
+func _play_sfx(sfx, position: Vector3):
+	vdb.voxel_world_player.play_sfx(sfx, position);
+
+	if server:
+		server.broadcast("play_sfx", [ sfx, position ]);
+
+func update_player_positions(uuid, left_hand_transform, right_hand_transform):
+	vdb.voxel_world_player.position_player(uuid, left_hand_transform, right_hand_transform);
+	
+	if server:
+		server.broadcast("position_player", [ uuid, left_hand_transform, right_hand_transform ]);
+
+func _send_crafting_status(uuid, voxel_pos, success, is_physical):
+	vdb.voxel_world_player.crafting_status(uuid, voxel_pos, success, is_physical);
+
+	if server:
+		server.broadcast_reliable("crafting_status", [ uuid, voxel_pos, success, is_physical ]);
+
+func _increment_build(voxel_position, hit_position, voxel_id):
+	var completed = vdb.voxel_world_player.increment_build(voxel_position, hit_position, voxel_id);
+
+	if server:
+		server.broadcast_reliable("increment_build", [ voxel_position, hit_position, voxel_id ]);
+	
+	return completed
+
+func add_voxel(uuid, pos, voxel_id, is_physical):
+	vdb.voxel_world_player.add_voxel(uuid, pos, voxel_id, is_physical);
+
+	if server:
+		server.broadcast_reliable("add_voxel", [ uuid, pos, voxel_id, is_physical ]);
+
+func _increment_destroy(voxel_position, hit_position, voxel_id, damage):
+	var completed = vdb.voxel_world_player.increment_destroy(voxel_position, hit_position, voxel_id, damage);
+
+	if server:
+		server.broadcast_reliable("increment_destroy", [ voxel_position, hit_position, voxel_id, damage ]);
+	
+	return completed
+
+func remove_voxel(uuid, pos, is_physical):
+	vdb.voxel_world_player.remove_voxel(uuid, pos, is_physical);
+
+	if server:
+		server.broadcast_reliable("remove_voxel", [ uuid, pos, is_physical ]);
+
+func _spawn_item(position, item_uuid, item_name):
+	vdb.voxel_world_player.spawn_item(position, item_uuid, item_name);
+
+	if server:
+		server.broadcast_reliable("spawn_item", [ position, item_uuid, item_name ]);
+
+func _delete_held_object(uuid, hand_name):
+	vdb.voxel_world_player.delete_player_held_object(uuid, hand_name);
+
+	if server:
+		server.broadcast_reliable("delete_player_held_object", [ uuid, hand_name ]);
+
+func _give_item(uuid, item_name):
+	var had_room = vdb.voxel_world_player.give_player_item(uuid, item_name);
+
+	if !had_room:
+		return false;
+		
+	if server:
+		server.broadcast_reliable("give_player_item", [ uuid, item_name ]);
+	
+	return true;
+
+func player_grab_item(uuid, hand_name, item_uuid):
+	vdb.voxel_world_player.player_grab_item(uuid, hand_name, item_uuid);
+
+	if server:
+		server.broadcast_reliable("player_grab_item", [ uuid, hand_name, item_uuid ]);
+
+func player_take_from_crate(uuid, hand_name, crate_position):
+	var item_uuid = vdb.gen_uuid();
+
+	vdb.voxel_world_player.player_take_from_crate(uuid, hand_name, crate_position, item_uuid);
+
+	if server:
+		server.broadcast_reliable("take_from_crate", [ uuid, hand_name, crate_position, item_uuid ]);
+
+func player_grab_from_inventory(uuid, hand_name, slot):
+	var item_uuid = vdb.gen_uuid();
+
+	vdb.voxel_world_player.grab_from_inventory(uuid, hand_name, slot, item_uuid);
+
+	if server:
+		server.broadcast_reliable("grab_from_inventory", [ uuid, hand_name, slot, item_uuid ]);
+
+func move_to_inventory(uuid, hand_name, slot):
+	vdb.voxel_world_player.move_to_inventory(uuid, hand_name, slot);
+	
+	if server:
+		server.broadcast_reliable("move_to_inventory", [ uuid, hand_name, slot ]);
+
+func set_player_active_slot(uuid, slot):
+	vdb.voxel_world_player.player_set_active_slot(uuid, slot);
+
+	if server:
+		server.broadcast_reliable("set_active_slot", [ uuid, slot ]);
+
+func move_to_tool_slot(uuid, hand_name, slot):
+	vdb.voxel_world_player.player_hand_to_tool(uuid, hand_name, slot);
+
+	if server:
+		server.broadcast_reliable("move_to_tool_slot", [ uuid, hand_name, slot ]);
+
+func move_tool_to_hand(uuid, slot, hand_name):
+	vdb.voxel_world_player.player_tool_to_hand(uuid, slot, hand_name);
+
+	if server:
+		server.broadcast_reliable("move_tool_to_hand", [ uuid, slot, hand_name ]);
+
+func player_release_item(uuid, hand_name, final_transform):
+	vdb.voxel_world_player.player_release_item(uuid, hand_name, final_transform);
+
+	if server:
+		server.broadcast_reliable("player_release_item", [ uuid, hand_name, final_transform ]);
+
+### helpers
+
+func get_player(uuid):
+	if uuid == vdb.voxel_world_player.uuid:
+		return vdb.voxel_world_player;
+	else:
+		return vdb.voxel_world_player.user_dummy_by_uuid[uuid];
+
+func _get_held_object(uuid, hand_name):
+	return get_player(uuid).get_held_object(hand_name);
+
+func _get_item_name_from_held_obj(held_obj):
+	if (!held_obj):
+		return "hand";
+
+	var item_def = held_obj.get_item_def();
+
+	if (!item_def):
+		return "hand";
+
+	return item_def.name;
+
+func _get_toolgroups_from_held_obj(held_obj):
+	if (!held_obj):
+		return [vdb.BYHAND];
+	
+	var item_def = held_obj.get_item_def();
+	
+	if (!item_def):
+		return [vdb.BYHAND];
+
+	return item_def.can_mine_groups;
+
+func get_voxel_id_from_pos(pos):
+	var voxel_pos = pos.floor();
+	var voxel_id = vdb.voxel_world_player._terrain_tool.get_voxel(voxel_pos);
+	return voxel_id;
+
+func get_voxel_def_from_pos(pos):
+	var voxel_id = get_voxel_id_from_pos(pos);
+	return vdb.voxel_block_defs[voxel_id];
+
+func can_break(voxel_pos, held_obj):
+	var voxel_id = vdb.voxel_world_player._terrain_tool.get_voxel(voxel_pos)
+	var voxel_block_def = vdb.voxel_block_defs[voxel_id];
+
+	if voxel_id == 0:
+		return false;
+	
+	# make sure the world allows you to break this
+	if (!vdb.voxel_world_player.terrain.stream.world_check_can_mine(voxel_id)):
+		return false;
+
+	# check that a crate is empty for mining it
+	if (voxel_id == vdb.voxel_block_names2id.wooden_crate):
+		var c = find_crate_for_voxel_pos(voxel_pos);
+		if (c != null && c._item_counter > 0): return false;
+
+	if (!voxel_block_def.can_mine): return false;
+	if (voxel_block_def.mine_groups == null): return false;
+
+	var tool_groups = _get_toolgroups_from_held_obj(held_obj);
+	
+	if !voxel_block_def.breakable_by_tool_groups:
+		return true;
+	
+	for mg in voxel_block_def.breakable_by_tool_groups:
+		for tg in tool_groups:
+			if (tg == mg):
+				return true;
+	return false
+
+func can_mine(voxel_block_def, held_obj):
+	var tool_groups = _get_toolgroups_from_held_obj(held_obj);
+
+	if (!tool_groups):
+		return false;
+	
+	for mg in voxel_block_def.mine_groups:
+		for tg in tool_groups:
+			if (tg == mg):
+				return true;
+	return false;
+
+# check surrounding voxel if sth. can be build there
+func can_build_at_pos(voxel_pos):
+
+	var voxel_at_pos = vdb.voxel_world_player._terrain_tool.get_voxel(voxel_pos);
+	if !_voxel_replacable(voxel_at_pos):
+		# cant place a voxel here
+		return false;
+
+	var testOffsets = [
+		Vector3(-1,  0,  0),
+		Vector3( 1,  0,  0),
+		Vector3( 0, -1,  0),
+		Vector3( 0,  1,  0),
+		Vector3( 0,  0, -1),
+		Vector3( 0,  0,  1)
+	];
+
+	# search for a non air block to place against
+	for offset in testOffsets:
+		if vdb.voxel_world_player._terrain_tool.get_voxel(voxel_pos + offset) != 0:
+			return true;
+	
+	return false;
+
+func _voxel_replacable(voxel_id):
+	var voxel_block_def = vdb.voxel_block_defs[voxel_id];
+	if (voxel_block_def.transparent):
+		return true;
+	return false;
+
+#hmm; slow... we should add a method to get actually world objects
+func find_crate_for_voxel_pos(voxel_pos):
+	var vid = get_voxel_id_from_pos(voxel_pos);
+
+	if (vid != vdb.voxel_block_names2id.wooden_crate):
+		return null;
+
+	var crate;
+	
+	for c in vdb.voxel_world_player.parent_container_crates.get_children():
+		if (c.global_transform.origin == voxel_pos):
+			crate = c;
+
+	if (crate == null):
+		crate = load("res://dynamic_objects/Container_Crate.tscn").instance();
+		crate.global_transform.origin = voxel_pos;
+		vdb.voxel_world_player.parent_container_crates.add_child(crate);
+
+	return crate;
+	
+### main logic
+
+func player_craft_with(uuid, voxel_pos, hand_name, is_physical):
+	var held_object = get_player(uuid).get_held_object(hand_name);
+
+	craft_with(uuid, voxel_pos, held_object, is_physical);
+
+func craft_with(uuid, voxel_pos, held_object, is_physical):
+	var crafting_grid;
+
+	for cg in vdb.voxel_world_player.parent_container_crafting_grids.get_children():
+		if cg.global_transform.origin == voxel_pos:
+			crafting_grid = cg;
+
+	if !crafting_grid:
+		return;
+	
+	var grid = crafting_grid.compute_craft_grid_def();	
+	var item_names = vdb.perform_crafting(grid, crafting_grid.crafting_grid_voxel_def, held_object);
+		
+	if !item_names:
+		_send_crafting_status(uuid, voxel_pos, false, is_physical);
+		return;
+
+	_send_crafting_status(uuid, voxel_pos, true, is_physical);
+
+	# spawn the crafted objects along the grid
+	var count = 0;
+	for item_name in item_names:
+		var grid_node = crafting_grid.grid_node_container.get_child(count);
+		_spawn_item(grid_node.global_transform.origin, vdb.gen_uuid(), item_name);
+		count = count + 1;
+
+# this is a basic way to add voxel destroyer logic with visualization
+func attempt_break(uuid, preferences, voxel_position, hit_position, hand_name, is_physical):
+	var held_obj = _get_held_object(uuid, hand_name);
+	
+	# here we check if the voxel_block has a specific definition of what tools
+	# can break it; if it is not breakable by the currently held tool we just
+	# return
+	if (!can_break(voxel_position, held_obj)):
+		return false;
+
+	var voxel_id = vdb.voxel_world_player._terrain_tool.get_voxel(voxel_position);
+	var voxel_block_def = vdb.voxel_block_defs[voxel_id];
+	
+	# here we will need to compute the damage based on the tool used
+	var dig_damage = 1;
+	var hack_damage = 0;
+	var chop_damage = 1;
+	
+	var item_def = null;
+	if (held_obj != null): item_def = held_obj.get_item_def(); # returns null if it is not an item
+	
+	if (item_def != null):
+		dig_damage = item_def.dig_damage;
+		hack_damage = item_def.hack_damage;
+		chop_damage = item_def.chop_damage;
+	
+	var damage =   max(dig_damage - voxel_block_def.dig_resistance, 0) \
+				 + max(hack_damage - voxel_block_def.hack_resistance, 0) \
+				 + max(chop_damage - voxel_block_def.chop_resistance, 0);
+	
+	if (damage <= 0): 
+		_play_sfx(vdb.sfx_cant_mine, hit_position);
+		return true; # we still return true as we attacked it;
+	
+	if (!is_physical): damage *= 0.5;
+	
+	# apply the actual damage now to the node; and check if it returns true
+	# which means the targeted voxel should be destroyed
+	if (_increment_destroy(voxel_position, hit_position, voxel_id, damage)):
+		_check_and_remove_voxel(uuid, voxel_position, is_physical);
+		
+		var mining_results = _compute_mining_results(voxel_block_def, held_obj);
+		
+		for def in mining_results:
+			if (!preferences.auto_put_in_inventory || !_give_item(uuid, def.name)):
+				_spawn_item(hit_position, vdb.gen_uuid(), def.name);
+	
+	return true;
+
+func _compute_mining_results(voxel_block_def, held_obj):
+	var ret = [];
+	
+	# now check if we can actually collect it:
+	if !can_mine(voxel_block_def, held_obj):
+		return ret;
+	
+	var item_name = _get_item_name_from_held_obj(held_obj);
+
+	if voxel_block_def.mine_results != null:
+		for mr in voxel_block_def.mine_results:
+			ret.append(vdb.get_def_from_name(mr));
+	else: # we just mine the actual block
+		ret.append(voxel_block_def);
+			
+	# check if we have special results for special mine items
+	if ("special_mine_items" in voxel_block_def && vdb.is_in_array(voxel_block_def.special_mine_items, item_name)):
+		for mr in voxel_block_def.special_mine_results:
+			ret.append(vdb.get_def_from_name(mr));
+	
+	return ret;
+
+# here I would like to perform additional checks to perform game logic
+# that needs to happen when a voxel is removed
+func _check_and_remove_voxel(uuid, voxel_position, is_physical):
+	remove_voxel(uuid, voxel_position, is_physical);
+	
+	var above_position = voxel_position + Vector3(0, 1, 0);
+	var voxel_def_above = get_voxel_def_from_pos(above_position);
+	
+	# for now we check via geometry_type; but this
+	if (voxel_def_above.geometry_type == vdb.GEOMETRY_TYPE.Plant):
+		remove_voxel(uuid, above_position, false);
+
+
+func attempt_build(uuid, voxel_position, hit_position, hand_name, is_physical):
+	var held_obj = _get_held_object(uuid, hand_name);
+
+	#var voxel_block_def = vdb.voxel_block_defs[1];
+	if (held_obj == null): return false; # can't build out of nothing
+	
+	var voxel_def = held_obj.get_voxel_def();
+	if (voxel_def == null): return false;
+
+	var voxel_id = voxel_def.id;
+
+	# increment until it returns true
+	if (_increment_build(voxel_position, hit_position, voxel_id)):
+		_delete_held_object(uuid, hand_name);
+		add_voxel(uuid, hit_position, voxel_id, is_physical);
+	
+	return true;

--- a/networking/SocketClient.gd
+++ b/networking/SocketClient.gd
@@ -1,0 +1,69 @@
+const SERVER_PORT = 1234;
+const MAX_MESSAGES_PER_TICK = 5;
+
+var event_listeners = {}
+
+var tcp_socket;
+
+var connected = false
+
+func connect_to_host(host):
+	tcp_socket = StreamPeerTCP.new();
+	
+	if tcp_socket.connect_to_host(host, SERVER_PORT) != OK:
+		_emit("disconnect", []);
+
+func disconnect_from_host():
+	if connected:
+		tcp_socket.disconnect_from_host();
+
+func send_reliable(event: String, args: Array):
+	if connected:
+		tcp_socket.put_string(event);
+		tcp_socket.put_var(args);
+
+func send(event: String, args: Array):
+	if connected:
+		# todo: udp
+		tcp_socket.put_string(event);
+		tcp_socket.put_var(args);
+
+func on(event, listener, callback):
+	event_listeners[event] = {
+		listener = listener,
+		callback = callback
+	};
+
+func update():
+	var status = tcp_socket.get_status();
+
+	# connecting
+	if status == tcp_socket.STATUS_CONNECTING:
+		return;
+	
+	if status == tcp_socket.STATUS_NONE || status == tcp_socket.STATUS_ERROR:
+		connected = false;
+		_emit("disconnect", []);
+		return;
+
+	if !connected:
+		tcp_socket.set_no_delay(true);
+		connected = true;
+		_emit("connect", []);
+	
+	var i = 0
+
+	while i < MAX_MESSAGES_PER_TICK && tcp_socket.get_available_bytes() > 0:
+		_handle_message(tcp_socket);
+		i += 1;
+
+func _handle_message(socket: StreamPeer):
+	var event = socket.get_string();
+	var args = socket.get_var();
+
+	_emit(event, args);
+
+func _emit(event: String, args):
+	var listenerInfo = event_listeners[event];
+	
+	listenerInfo.listener.callv(listenerInfo.callback, args);

--- a/networking/SocketServer.gd
+++ b/networking/SocketServer.gd
@@ -1,0 +1,129 @@
+const SERVER_PORT = 1234;
+const MAX_PLAYERS = 4;
+
+var tcp_server;
+var tcp_sockets = []
+var kick_list = [];
+var ids = [];
+var available_ids = [];
+var id_to_tcp_socket = {}
+var event_listeners = {}
+
+func start():
+	tcp_server = TCP_Server.new();
+	tcp_server.listen(SERVER_PORT);
+
+	for i in range(MAX_PLAYERS):
+		available_ids.push_back(i);
+
+func stop():
+	for socket in tcp_sockets:
+		socket.disconnect_from_host();
+	tcp_server.stop();
+
+func send_reliable(id: int, event: String, args: Array):
+	var socket = id_to_tcp_socket[id];
+	socket.put_string(event);
+	socket.put_var(args);
+
+func send(id: int, event: String, args: Array):
+	# todo: udp
+	var socket = id_to_tcp_socket[id];
+	socket.put_string(event);
+	socket.put_var(args);
+
+func broadcast_reliable(event: String, args: Array):
+	for socket in tcp_sockets:
+		socket.put_string(event);
+		socket.put_var(args);
+
+func broadcast(event: String, args: Array):
+	# todo: udp
+	for socket in tcp_sockets:
+		socket.put_string(event);
+		socket.put_var(args);
+
+func kick(id: int):
+	kick_list.push_back(id);
+
+func on(event, listener, callback):
+	event_listeners[event] = {
+		listener = listener,
+		callback = callback
+	};
+
+func update():
+	if tcp_server.is_connection_available():
+		var socket = tcp_server.take_connection();
+		socket.set_no_delay(true);
+		
+		if tcp_sockets.size() < MAX_PLAYERS - 1:
+			var id = available_ids.pop_back();
+			id_to_tcp_socket[id] = socket;
+			
+			ids.push_back(id);
+			tcp_sockets.push_back(socket);
+			
+			_emit("connect", id, []);
+		else:
+			socket.disconnect_from_host();
+	
+	for id in kick_list:
+		_remove_by_id(id);
+	
+	kick_list.clear();
+	
+	var disconnectedSockets = [];
+	
+	for i in range(tcp_sockets.size()):
+		var socket = tcp_sockets[i];
+		var id = ids[i];
+	
+		if !socket.is_connected_to_host():
+			disconnectedSockets.push_back(i);
+			_emit("disconnect", id, []);
+			continue;
+		
+		# handle just one message per tick
+		if socket.get_available_bytes() > 0:
+			_handle_message(socket, id);
+	
+	for i in disconnectedSockets:
+		_remove_by_index(i);
+
+func _remove_by_id(id):
+	var i = ids.find(id);
+
+	if i != -1:
+		_remove_by_index(i);
+
+func _remove_by_index(i):
+	var id = ids[i];
+	
+	id_to_tcp_socket.erase(id);
+	available_ids.push_back(id);
+	
+	ids.remove(i);
+	tcp_sockets.remove(i);
+
+
+func _handle_message(socket: StreamPeer, socketid: int):
+	var event = socket.get_string();
+	var args = socket.get_var();
+	
+	_emit(event, socketid, args);
+
+func _emit(event: String, socketid: int, args):
+	var listenerInfo = event_listeners[event];
+	
+	if listenerInfo == null:
+		vr.log_error("No listener for " + event);
+		return
+	
+	if !(args is Array):
+		vr.log_error("Malformed message");
+		return
+	
+	args.push_front(socketid);
+	
+	listenerInfo.listener.callv(listenerInfo.callback, args);

--- a/project.godot
+++ b/project.godot
@@ -35,6 +35,7 @@ config/icon="res://data/graphics2d/icons/icon_64.png"
 vr="*res://OQ_Toolkit/vr_autoload.gd"
 vdb="*res://VoxelDatabase.gd"
 Firebase="*res://networking/firebase.gd"
+core="*res://logic/core.gd"
 
 [display]
 

--- a/ui/IngameMenu_MainUI.gd
+++ b/ui/IngameMenu_MainUI.gd
@@ -32,7 +32,8 @@ func _on_Game_Save_Button_pressed():
 
 
 func _on_Game_ExitToMainMenu_Button_pressed():
-	_game_status_label.text = "Saveing & leaving game...";
+	_game_status_label.text = "Saving & leaving game...";
+	vdb.voxel_world_player._save_all();
 	vdb.voxel_world_player._back_to_main_menu();
 
 


### PR DESCRIPTION
This pr adds multiplayer, a world can be served or joined using options `host` and `remote_host` in `startup_settings`.

Networking is handled in SocketClient and SocketServer, everything outside of those files are events + event triggers. This currently uses TCP but the protocol can changed entirely by just modifying those two files.

Structure changes:
 * Some logic for modifying blocks was split off into core.gd
   * core.gd is server logic/redirection that is called by users running a server or single player
   * This could and probably should be renamed
 * Calls to different actions are indirect and bounce from VoxelWorldPlayer to core and back
 * Grabbing and releasing items is achieved through requests (indirection)
 * check_and_put functions switched for can_put (client->server prereq) and put_in (server->client)

Steps for different stages of release:
 * alpha:
   * UI to join and host worlds (and listing the quest's local ip with IP.get_local_addresses())
   * Player models for PlayerDummy and sending player locations (only hands are currently synced)
   * Preventing items from being deleted when a client user leaves (drop inventory or saving)
 * beta:
   * Saving player data and storing the player's uuid for loading data
   * Spawning new players near the host
   * Restricting players from getting too far from the host (can't place or break blocks, lag and other issues may occur)
   * Preventing multiple players from grabbing the same item
 * completion:
   * Port customization (currently it's 1234)
   * LAN discovery
   * Separate server relay project (or maybe WebRTC?) to avoid port forwarding
   * Player customization?  