### PR TITLE
Player models and bug fixes

### DIFF
--- a/dynamic_objects/PlayerDummy.tscn
+++ b/dynamic_objects/PlayerDummy.tscn
@@ -4,3 +4,9 @@
 
 [node name="Spatial" type="Spatial"]
 script = ExtResource( 1 )
+
+[node name="Head" type="Spatial" parent="."]
+
+[node name="Left_Hand" type="Spatial" parent="."]
+
+[node name="Right_Hand" type="Spatial" parent="."]

--- a/dynamic_objects/scripts/Inventory.gd
+++ b/dynamic_objects/scripts/Inventory.gd
@@ -202,6 +202,12 @@ func hide_inventory():
 	visible = false;
 	$Area.monitorable = false;
 
+func clear():
+	for i in range(0, _inventory.size()):
+		_inventory[i][0] = null;
+		_inventory[i][1] = 0;
+
+
 var _active_inventory_controller = null;
 
 func _check_display_inventory_gesture(controller : ARVRController):

--- a/dynamic_objects/scripts/Toolbelt.gd
+++ b/dynamic_objects/scripts/Toolbelt.gd
@@ -48,6 +48,11 @@ func apply_save_dictionary(r : Dictionary):
 		else:
 			vr.log_error("Could not load object from " + str(item));
 
+func clear():
+	for slot in $Slots.get_children():
+		for child in slot.get_children():
+			child.queue_free();
+
 
 func _physics_process(_dt):
 	global_transform.origin = vr.vrCamera.global_transform.origin;

--- a/levels/VoxelWorldPlayer.gd
+++ b/levels/VoxelWorldPlayer.gd
@@ -119,6 +119,7 @@ func add_player(player_uuid):
 		return;
 	
 	var dummy = _player_dummy.instance();
+	dummy.uuid = player_uuid;
 	user_dummy_by_uuid[player_uuid] = dummy;
 	parent_world.add_child(dummy);
 

--- a/levels/VoxelWorldPlayer.gd
+++ b/levels/VoxelWorldPlayer.gd
@@ -970,6 +970,10 @@ func _back_to_main_menu():
 
 	user_dummy_by_uuid = {};
 
+	# clear inventory for next world
+	_player_inventory.clear();
+	_player_toolbelt.clear();
+
 	var parent = get_parent();
 
 	if parent:

--- a/logic/core.gd
+++ b/logic/core.gd
@@ -97,7 +97,7 @@ func _user_connected(id: int):
 	var player_data = [ vdb.voxel_world_player.gen_player_data() ];
 	
 	for dummy_player in vdb.voxel_world_player.user_dummy_by_uuid.values():
-		dummy_player.gen_player_data();
+		player_data.push_back(dummy_player.gen_player_data());
 
 	server.send_reliable(id, "world_data", [ world_data, player_data ]);
 

--- a/logic/core.gd
+++ b/logic/core.gd
@@ -112,14 +112,16 @@ func _load_user(id: int, uuid: String, preferences: Dictionary):
 		preferences = preferences
 	};
 
-	vdb.voxel_world_player.add_player(uuid);
+	var pid = id + 1;
 
-	server.broadcast_reliable("add_player", [ uuid ]);
+	vdb.voxel_world_player.add_player(uuid, pid);
 
-func _position_player(id: int, left_hand_transform, right_hand_transform):
+	server.broadcast_reliable("add_player", [ uuid, pid ]);
+
+func _position_player(id: int, head_transform, left_hand_transform, right_hand_transform):
 	var user = users_by_socket_id[id];
 	
-	update_player_positions(user.uuid, left_hand_transform, right_hand_transform);
+	update_player_positions(user.uuid, head_transform, left_hand_transform, right_hand_transform);
 
 func _user_disconnected(id: int):
 	var user = users_by_socket_id[id];
@@ -199,11 +201,11 @@ func _play_sfx(sfx, position: Vector3):
 	if server:
 		server.broadcast("play_sfx", [ sfx, position ]);
 
-func update_player_positions(uuid, left_hand_transform, right_hand_transform):
-	vdb.voxel_world_player.position_player(uuid, left_hand_transform, right_hand_transform);
+func update_player_positions(uuid, head_transform, left_hand_transform, right_hand_transform):
+	vdb.voxel_world_player.position_player(uuid, head_transform, left_hand_transform, right_hand_transform);
 	
 	if server:
-		server.broadcast("position_player", [ uuid, left_hand_transform, right_hand_transform ]);
+		server.broadcast("position_player", [ uuid, head_transform, left_hand_transform, right_hand_transform ]);
 
 func _send_crafting_status(uuid, voxel_pos, success, is_physical):
 	vdb.voxel_world_player.crafting_status(uuid, voxel_pos, success, is_physical);

--- a/networking/SocketServer.gd
+++ b/networking/SocketServer.gd
@@ -13,8 +13,8 @@ func start():
 	tcp_server = TCP_Server.new();
 	tcp_server.listen(SERVER_PORT);
 
-	for i in range(MAX_PLAYERS):
-		available_ids.push_back(i);
+	for i in range(MAX_PLAYERS - 1):
+		available_ids.push_front(i);
 
 func stop():
 	for socket in tcp_sockets:


### PR DESCRIPTION
Fixes syncing for players 3+, and inventories from a previous world from being carried into a new world or a connecting world.

Temporary player models added, uses tree logs for heads and clouds for hands. Player one is aspen to make the host stand out.