### PR TITLE
Use hand transform to rotate crafting grid

### DIFF
--- a/dynamic_objects/CraftingGrid.tscn
+++ b/dynamic_objects/CraftingGrid.tscn
@@ -36,6 +36,7 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.5, 0.5, 0.5 )
 shape = SubResource( 1 )
 
 [node name="GridNodes" type="Spatial" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.5, 0, 0.5 )
 
 [node name="GridPoint" type="MeshInstance" parent="."]
 visible = false

--- a/dynamic_objects/scripts/CraftingGrid.gd
+++ b/dynamic_objects/scripts/CraftingGrid.gd
@@ -12,6 +12,8 @@ var _reset_counter = 0.0;
 var _num_build_steps = 4.0;
 var _build_step = 0.0;
 
+var block_rotation;
+
 var crafting_grid_voxel_def = null; # this is the voxel def that spawned this table
 
 # a furnace with fuel would be auto-craft
@@ -27,8 +29,9 @@ onready var indicator_invalid = $CraftIndicator/CraftIndicatorInvalid;
 const COLOR_valid_recipe = Color(0,0.521569,0,0.392157);
 const COLOR_invalid_recipe = Color(0.521569,0,1,0.392157);
 
-func initialize_crafting_grid(vid):
+func initialize_crafting_grid(vid, rotation_deg):
 	crafting_grid_voxel_def = vdb.voxel_block_defs[vid];
+	block_rotation = rotation_deg;
 	
 	if (vid == vdb.voxel_block_names2id.furnace):
 		is_furnace = true;
@@ -199,14 +202,16 @@ func _check_and_update_valid():
 func _ready():
 	$GridPoint.visible = false;
 	$Animated_Fire.visible = false;
+
+	grid_node_container.rotation_degrees.y = block_rotation;
 	
 	for y in range(0, grid_size):
 		for x in range(0, grid_size):
 			var g = Spatial.new();
 			grid_node_container.add_child(g);
-			var px = (x+0.5) / float(grid_size);
+			var px = (x-1) / float(grid_size);
 			var py = (y+0.5) / float(grid_size);
-			var pz = 0.5;
+			var pz = 0;
 			g.transform.origin = Vector3(px, py, pz);
 			
 			var marker = $GridPoint.duplicate();

--- a/dynamic_objects/scripts/CraftingGrid.gd
+++ b/dynamic_objects/scripts/CraftingGrid.gd
@@ -81,7 +81,7 @@ func can_attempt_craft(global_pos):
 		return false;
 	return true;
 
-func attempt_craft(held_object, is_physical):
+func attempt_craft():
 	#print("PLING");
 	_reset_counter = 0.0;
 	_build_step = _build_step + 1;

--- a/levels/VoxelWorldPlayer.gd
+++ b/levels/VoxelWorldPlayer.gd
@@ -571,8 +571,10 @@ func _check_and_start_crafting(held_object):
 		#print(vdb.voxel_block_names2id.tree);
 		# We can craft on top of tree trunks for now
 		if (_is_a_crafting_voxel(vid_below)):
+			var rotation = floor((held_object.rotation_degrees.y + 45) / 90) * 90;
+
 			var cg : Spatial = load("res://dynamic_objects/CraftingGrid.tscn").instance();
-			cg.initialize_crafting_grid(vid_below);
+			cg.initialize_crafting_grid(vid_below, rotation);
 			parent_container_crafting_grids.add_child(cg);
 			cg.global_transform.origin = pos.floor();
 			cg.check_craft_place(held_object);

--- a/levels/VoxelWorldPlayer.gd
+++ b/levels/VoxelWorldPlayer.gd
@@ -636,7 +636,7 @@ func check_attack_voxel(pos: Vector3, _speed, hand_name, is_physical):
 	# check if we are hitting a crafting area
 	for cg in parent_container_crafting_grids.get_children():
 		if (cg.can_attempt_craft(pos)):
-			if cg.attempt_craft(hand_name, is_physical):
+			if cg.attempt_craft():
 				_attempt_craft(voxel_pos, hand_name, is_physical);
 			return true;
 	


### PR DESCRIPTION
Uses the item/hand transform to decide the initial crafting grid rotation (4 directions)